### PR TITLE
Add build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,16 @@
+Build
+=====
+
+.. code-block:: bash
+
+  sudo apt-get update
+  sudo apt-get install libtalloc-dev uthash-dev libarchive-dev gdb strace realpath
+  sudo pip install cpp-coveralls
+
+  make -C src loader.exe loader-m32.exe build.h && env CFLAGS=--coverage LDFLAGS='--coverage' make -C src proot && env PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PWD/src make -C tests
+
+
+
 Manuals
 =======
 


### PR DESCRIPTION
These were the instructions I used to get `proot` built in the `src/` folder on a debian system.

Pulled from `.travis.yml` https://github.com/brianmcmichael/PRoot/blob/master/.travis.yml#L5-L10